### PR TITLE
CHORE: rename docker service web and images

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -22,18 +22,18 @@ jobs:
         run: |
           echo "Waiting for container to be healthy..."
           for i in {1..30}; do
-            if docker compose exec web python -c "import socket; s = socket.socket(); s.connect(('localhost', 6060))"; then
+            if docker compose exec api python -c "import socket; s = socket.socket(); s.connect(('localhost', 6060))"; then
               echo "Container is healthy!"
               break
             fi
             sleep 1
           done
           # Check one last time and fail if not ready
-          docker compose exec web python -c "import socket; s = socket.socket(); s.connect(('localhost', 6060))"
+          docker compose exec api python -c "import socket; s = socket.socket(); s.connect(('localhost', 6060))"
 
       - name: Run tests inside the container
         run: |
-          docker compose exec web python -m pytest
+          docker compose exec api pytest
 
       - name: View logs on failure
         if: failure()

--- a/compose.debug.yaml
+++ b/compose.debug.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: client-server
+    image: graymattermetrics/cerebrum
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/compose.debug.yaml
+++ b/compose.debug.yaml
@@ -1,5 +1,5 @@
 services:
-  graymattermetricsclientserver:
+  api:
     image: client-server
     build:
       context: .

--- a/compose.debug.yaml
+++ b/compose.debug.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: graymattermetrics/cerebrum
+    image: graymattermetrics/cerebrum:debug
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: client-server
+    image:  graymattermetrics/cerebrum
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    image:  graymattermetrics/cerebrum
+    image: graymattermetrics/cerebrum
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  web:
+  api:
     image: client-server
     build:
       context: .


### PR DESCRIPTION
I have changed the docker compose service name to api as mentioned in the readme file. I have also taken the liberty to rename the image to graymattermetrics/cerebrum in case graymattermetrics decides to publish the image to docker hub 